### PR TITLE
fix phplint warnings

### DIFF
--- a/lib/Horde/Xml/Wbxml/Decoder.php
+++ b/lib/Horde/Xml/Wbxml/Decoder.php
@@ -89,7 +89,7 @@ class Horde_Xml_Wbxml_Decoder extends Horde_Xml_Wbxml_ContentHandler
      */
     public function getByte($input)
     {
-        return ord($input{$this->_strpos++});
+        return ord($input[$this->_strpos++]);
     }
 
     /**

--- a/lib/Horde/Xml/Wbxml/Encoder.php
+++ b/lib/Horde/Xml/Wbxml/Encoder.php
@@ -49,7 +49,7 @@ class Horde_Xml_Wbxml_Encoder extends Horde_Xml_Wbxml_ContentHandler
     /**
      * Constructor.
      */
-    public function Horde_Xml_Wbxml_Encoder()
+    public function __construct()
     {
         $this->_dtdManager = new Horde_Xml_Wbxml_DtdManager();
         $this->_stringTable = new Horde_Xml_Wbxml_HashTable();
@@ -213,7 +213,7 @@ class Horde_Xml_Wbxml_Encoder extends Horde_Xml_Wbxml_ContentHandler
 
         $bytes = array();
         for ($i = 0; $i < $nbytes; $i++) {
-            $bytes[] = $string{$i};
+            $bytes[] = $string[$i];
         }
 
         return $bytes;
@@ -422,7 +422,7 @@ class Horde_Xml_Wbxml_Encoder extends Horde_Xml_Wbxml_ContentHandler
             $this->_output .= chr(Horde_Xml_Wbxml::GLOBAL_TOKEN_SWITCH_PAGE);
             $this->_output .= chr($cp);
         } else {
-            $this->_subParser = new Horde_Xml_Wbxml_Encoder(true);
+            $this->_subParser = new Horde_Xml_Wbxml_Encoder();
             $this->_subParserStack = 1;
         }
     }


### PR DESCRIPTION
```
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in lib/Horde/Xml/Wbxml/Encoder.php on line 216
PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; Horde_Xml_Wbxml_Encoder has a deprecated constructor in lib/Horde/Xml/Wbxml/Encoder.php on line 14
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in lib/Horde/Xml/Wbxml/Decoder.php on line 92

```